### PR TITLE
Update filterSearch.js - Check nullability of filteredItems object

### DIFF
--- a/packages/venia-ui/lib/components/FilterModal/FilterSearch/filterSearch.js
+++ b/packages/venia-ui/lib/components/FilterModal/FilterSearch/filterSearch.js
@@ -63,7 +63,7 @@ const withFilterSearch = WrappedComponent => {
                             {getSearchInput}
                         </Form>
                     )}
-                    {filteredItems.length > 0 ? (
+                    {filteredItems && filteredItems.length > 0 ? (
                         <WrappedComponent
                             {...rest}
                             classes={classes}


### PR DESCRIPTION
## Description

This pull request is to verify filteredItems object nullability. If the object is null when filtered values returns null, then its throwing error that length cannot be performed on null object. So, proposing to verify the nullability of the object as below:

{ **filteredItems** && filteredItems.length > 0 ? (

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the FOO page.
2. Verify the BAR shows up.
3. Make sure BAZ does a thing.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
No documentation and test cases are necessary for this change.
